### PR TITLE
refactor: use `ugui.label` instead of drawing text with BreitbandGraphics

### DIFF
--- a/src/core/Drawing.lua
+++ b/src/core/Drawing.lua
@@ -11,6 +11,12 @@ Drawing = {
     offset_stack = {},
 }
 
+local UID = UIDProvider.allocate_once('Drawing', function(enum_next)
+    return {
+        SettingListLabelBase = enum_next(64),
+    }
+end)
+
 function Drawing.size_up()
     Drawing.initial_size = wgui.info()
     Drawing.scale = (Drawing.initial_size.height - 23) / 600
@@ -94,15 +100,16 @@ function Drawing.setting_list(items, pos)
     for i = 1, #items, 1 do
         local item = items[i]
 
-        BreitbandGraphics.draw_text(
-            grid_rect(pos.x, y, 8, 0.5),
-            'start',
-            'center',
-            { aliased = not theme.cleartype },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            theme.font_name,
-            item.text())
+        ugui.label({
+            uid = UID.SettingListLabelBase + i,
+            rectangle = grid_rect(pos.x, y, 8, 0.5),
+            text = item.text(),
+            color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = theme.font_name,
+            align_x = BreitbandGraphics.alignment['start'],
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         item.func(grid_rect(pos.x, y + 0.6, 4, 1))
 

--- a/src/core/MiniVisualizer.lua
+++ b/src/core/MiniVisualizer.lua
@@ -14,6 +14,9 @@ local UID = UIDProvider.allocate_once('MiniVisualizer', function(enum_next)
         Z = enum_next(),
         S = enum_next(),
         R = enum_next(),
+        Action = enum_next(),
+        JoystickX = enum_next(),
+        JoystickY = enum_next(),
     }
 end)
 
@@ -65,31 +68,35 @@ MiniVisualizer.draw = function()
         is_checked = Joypad.input.R,
     })
     local foreground_color = ugui.standard_styler.params.button.text[ugui.visual_states.normal]
-    BreitbandGraphics.draw_text(
-        grid_rect_abs(3, 15, 5, 1),
-        'center',
-        'center',
-        { aliased = not Styles.theme().cleartype },
-        foreground_color,
-        Styles.theme().font_size * Drawing.scale,
-        'Consolas',
-        VarWatch_compute_value('action'))
-    BreitbandGraphics.draw_text(
-        grid_rect_abs(3, 14, 2.5, 1),
-        'center',
-        'center',
-        { aliased = not Styles.theme().cleartype },
-        foreground_color,
-        Styles.theme().font_size * Drawing.scale * 1.25,
-        'Consolas',
-        'X: ' .. Joypad.input.X)
-    BreitbandGraphics.draw_text(
-        grid_rect_abs(5.5, 14, 2.5, 1),
-        'center',
-        'center',
-        { aliased = not Styles.theme().cleartype },
-        foreground_color,
-        Styles.theme().font_size * Drawing.scale * 1.25,
-        'Consolas',
-        'Y: ' .. Joypad.input.Y)
+    local theme = Styles.theme()
+    ugui.label({
+        uid = UID.Action,
+        rectangle = grid_rect_abs(3, 15, 5, 1),
+        text = VarWatch_compute_value('action'),
+        color = foreground_color,
+        font_size = theme.font_size * Drawing.scale,
+        font_name = 'Consolas',
+        align_x = BreitbandGraphics.alignment.center,
+        align_y = BreitbandGraphics.alignment.center,
+    })
+    ugui.label({
+        uid = UID.JoystickX,
+        rectangle = grid_rect_abs(3, 14, 2.5, 1),
+        text = 'X: ' .. Joypad.input.X,
+        color = foreground_color,
+        font_size = theme.font_size * Drawing.scale * 1.25,
+        font_name = 'Consolas',
+        align_x = BreitbandGraphics.alignment.center,
+        align_y = BreitbandGraphics.alignment.center,
+    })
+    ugui.label({
+        uid = UID.JoystickY,
+        rectangle = grid_rect_abs(5.5, 14, 2.5, 1),
+        text = 'Y: ' .. Joypad.input.Y,
+        color = foreground_color,
+        font_size = theme.font_size * Drawing.scale * 1.25,
+        font_name = 'Consolas',
+        align_x = BreitbandGraphics.alignment.center,
+        align_y = BreitbandGraphics.alignment.center,
+    })
 end

--- a/src/views/Notifications.lua
+++ b/src/views/Notifications.lua
@@ -6,6 +6,12 @@
 
 local notifications = {}
 
+local UID = UIDProvider.allocate_once('Notifications', function(enum_next)
+    return {
+        NotificationBase = enum_next(8),
+    }
+end)
+
 -- For now, we only show one notification at a time, as opacity and slide animations are pretty distracting.
 
 return {
@@ -52,20 +58,16 @@ return {
                 { x = x, y = y, width = size.width, height = size.height },
                 theme.background_color)
 
-            BreitbandGraphics.draw_text(
-                {
-                    x = x,
-                    y = y,
-                    width = size.width + 1,
-                    height = size.height + 1,
-                },
-                'start',
-                'start',
-                { aliased = not theme.cleartype },
-                foreground_color,
-                theme.font_size * Drawing.scale * text_scale,
-                theme.font_name,
-                notification.text)
+            ugui.label({
+                uid = UID.NotificationBase + i,
+                rectangle = { x = x, y = y, width = size.width + 1, height = size.height + 1 },
+                text = notification.text,
+                color = foreground_color,
+                font_size = theme.font_size * Drawing.scale * text_scale,
+                font_name = theme.font_name,
+                align_x = BreitbandGraphics.alignment['start'],
+                align_y = BreitbandGraphics.alignment['start'],
+            })
         end
 
         local notifications_copy = ugui.internal.deep_clone(notifications)

--- a/src/views/SemanticWorkflow/Help.lua
+++ b/src/views/SemanticWorkflow/Help.lua
@@ -30,32 +30,35 @@ return {
                 SemanticWorkflowDialog = nil
             end
 
-            BreitbandGraphics.draw_text2({
+            ugui.label({
+                uid = UID.HelpTitle,
                 rectangle = grid_rect(0, 0.1, 8, 1),
                 text = title,
-                align_x = BreitbandGraphics.alignment.start,
-                align_y = BreitbandGraphics.alignment.start,
                 color = foreground_color,
                 font_size = theme.font_size * 1.2 * Drawing.scale,
                 font_name = theme.font_name,
-            })
-            BreitbandGraphics.draw_text2({
-                rectangle = grid_rect(0, 0.666, 8, 1),
-                text = pages[page]['HEADING'],
                 align_x = BreitbandGraphics.alignment.start,
                 align_y = BreitbandGraphics.alignment.start,
+            })
+            ugui.label({
+                uid = UID.HelpPageHeading,
+                rectangle = grid_rect(0, 0.666, 8, 1),
+                text = pages[page]['HEADING'],
                 color = foreground_color,
                 font_size = theme.font_size * 2 * Drawing.scale,
                 font_name = theme.font_name,
-            })
-            BreitbandGraphics.draw_text2({
-                rectangle = grid_rect(0, 1.8, 8, 1),
-                text = pages[page]['TEXT'],
                 align_x = BreitbandGraphics.alignment.start,
                 align_y = BreitbandGraphics.alignment.start,
+            })
+            ugui.label({
+                uid = UID.HelpPageText,
+                rectangle = grid_rect(0, 1.8, 8, 1),
+                text = pages[page]['TEXT'],
                 color = foreground_color,
                 font_size = theme.font_size * Drawing.scale,
                 font_name = theme.font_name,
+                align_x = BreitbandGraphics.alignment.start,
+                align_y = BreitbandGraphics.alignment.start,
             })
 
             if ugui.button(

--- a/src/views/SemanticWorkflow/Implementations/InputsTab.lua
+++ b/src/views/SemanticWorkflow/Implementations/InputsTab.lua
@@ -64,6 +64,7 @@ local UID = UIDProvider.allocate_once('InputsTab', function(enum_next)
         AtanReverse = enum_next(),
         AtanRetime = enum_next(),
         AtanButtons = enum_next(8),
+        AtanFieldLabels = enum_next(8),
         SpeedKick = enum_next(),
         ResetMag = enum_next(),
         Swim = enum_next(),
@@ -365,16 +366,16 @@ local function atan_controls(draw, sheet, new_values, top)
     local function atan_field(index, text, table, field, increment, low_bound, high_bound)
         local width = 1.6
         local x = index * width
-        BreitbandGraphics.draw_text(
-            grid_rect(x, top + 1, width, 0.5),
-            'center',
-            'center',
-            { aliased = not theme.cleartype, fit = true },
-            foreground_color,
-            theme.font_size * Drawing.scale,
-            'Consolas',
-            text .. tostring(table[field])
-            )
+        ugui.label({
+            uid = UID.AtanFieldLabels + index,
+            rectangle = grid_rect(x, top + 1, width, 0.5),
+            text = text .. tostring(table[field]),
+            color = foreground_color,
+            font_size = theme.font_size * Drawing.scale,
+            font_name = 'Consolas',
+            align_x = BreitbandGraphics.alignment.center,
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         if ugui.button({
             uid = UID.AtanButtons + index * 2,

--- a/src/views/SemanticWorkflow/Implementations/ProjectTab.lua
+++ b/src/views/SemanticWorkflow/Implementations/ProjectTab.lua
@@ -28,6 +28,8 @@ local UID = UIDProvider.allocate_once('ProjectTab', function(enum_next)
         AddSheet = enum_next(),
         ConfirmationYes = enum_next(),
         ConfirmationNo = enum_next(),
+        ConfirmationText = enum_next(),
+        NoSheetsLabel = enum_next(),
     }
 end)
 
@@ -42,14 +44,15 @@ local function create_confirm_dialog(prompt, on_confirmed)
 
         local theme = Styles.theme()
 
-        BreitbandGraphics.draw_text2({
+        ugui.label({
+            uid = UID.ConfirmationText,
             rectangle = grid_rect(0, top - 8, 8, 8),
             text = prompt,
-            align_x = BreitbandGraphics.alignment.center,
-            align_y = BreitbandGraphics.alignment['end'],
             color = theme.button.text[1],
             font_size = theme.font_size * 1.2 * Drawing.scale,
             font_name = theme.font_name,
+            align_x = BreitbandGraphics.alignment.center,
+            align_y = BreitbandGraphics.alignment['end'],
         })
 
         if ugui.button({
@@ -100,14 +103,15 @@ local RenderConfirmPurgeDialog = create_confirm_dialog(
 function __impl.render(draw)
     local theme = Styles.theme()
     if #SemanticWorkflowProject.all == 0 then
-        BreitbandGraphics.draw_text2({
+        ugui.label({
+            uid = UID.NoSheetsLabel,
             rectangle = grid_rect(0, 0, 8, 16),
             text = Locales.str('SEMANTIC_WORKFLOW_PROJECT_NO_SHEETS_AVAILABLE'),
-            align_x = BreitbandGraphics.alignment.center,
-            align_y = BreitbandGraphics.alignment.center,
             color = theme.button.text[1],
             font_size = theme.font_size * 1.2 * Drawing.scale,
             font_name = theme.font_name,
+            align_x = BreitbandGraphics.alignment.center,
+            align_y = BreitbandGraphics.alignment.center,
         })
     end
 

--- a/src/views/SemanticWorkflow/Main.lua
+++ b/src/views/SemanticWorkflow/Main.lua
@@ -95,34 +95,41 @@ local Tabs = dofile(views_path .. 'SemanticWorkflow/Tabs.lua')
 local selected_tab_index = 1
 
 local function draw_factory(theme)
+    local uid_counter = 0
+    local function next_uid()
+        local uid = UID.DrawTextBase + uid_counter
+        uid_counter = uid_counter + 1
+        return uid
+    end
+
     return {
         foreground_color = Drawing.foreground_color(),
         background_color = theme.background_color,
         font_size = theme.font_size * Drawing.scale * 0.75,
 
         text = function(self, rect, horizontal_alignment, text)
-            BreitbandGraphics.draw_text2({
+            ugui.label({
+                uid = next_uid(),
                 rectangle = rect,
                 text = text,
-                align_x = BreitbandGraphics.alignment[horizontal_alignment],
-                align_y = BreitbandGraphics.alignment.center,
-                aliased = theme.pixelated_text,
                 color = self.foreground_color,
                 font_size = self.font_size,
                 font_name = 'Consolas',
+                align_x = BreitbandGraphics.alignment[horizontal_alignment],
+                align_y = BreitbandGraphics.alignment.center,
             })
         end,
 
         small_text = function(self, rect, horizontal_alignment, text)
-            BreitbandGraphics.draw_text2({
+            ugui.label({
+                uid = next_uid(),
                 rectangle = rect,
                 text = text,
-                align_x = BreitbandGraphics.alignment[horizontal_alignment],
-                align_y = BreitbandGraphics.alignment.center,
-                aliased = theme.pixelated_text,
                 color = self.foreground_color,
                 font_size = self.font_size * 0.75,
                 font_name = 'Consolas',
+                align_x = BreitbandGraphics.alignment[horizontal_alignment],
+                align_y = BreitbandGraphics.alignment.center,
             })
         end,
     }

--- a/src/views/SemanticWorkflow/SharedUIDs.lua
+++ b/src/views/SemanticWorkflow/SharedUIDs.lua
@@ -5,5 +5,9 @@ return UIDProvider.allocate_once("SemanticWorkflow", function(enum_next)
         ToggleHelp = enum_next(),
         HelpNext = enum_next(),
         HelpBack = enum_next(),
+        HelpTitle = enum_next(),
+        HelpPageHeading = enum_next(),
+        HelpPageText = enum_next(),
+        DrawTextBase = enum_next(256),
     }
 end)

--- a/src/views/TAS.lua
+++ b/src/views/TAS.lua
@@ -21,10 +21,14 @@ local UID = UIDProvider.allocate_once('TAS', function(enum_next)
         AtanStrain = enum_next(),
         AtanStrainReverse = enum_next(),
         AtanButtons = enum_next(20),
+        AtanFieldLabels = enum_next(8),
         MovementModeDisabled = enum_next(),
         MovementModeMatchYaw = enum_next(),
         MovementModeReverseYaw = enum_next(),
         MovementModeMatchAngle = enum_next(),
+        StickX = enum_next(),
+        StickY = enum_next(),
+        StickMag = enum_next(),
     }
 end)
 
@@ -166,15 +170,16 @@ return {
             local function atan_field(index, text, up_callback, down_callback)
                 local width = 1.6
                 local x = index * width
-                BreitbandGraphics.draw_text(
-                    grid_rect(x, 3, width, 0.5),
-                    'center',
-                    'center',
-                    { aliased = not theme.cleartype, fit = true },
-                    foreground_color,
-                    theme.font_size * Drawing.scale,
-                    'Consolas',
-                    text)
+                ugui.label({
+                    uid = UID.AtanFieldLabels + index,
+                    rectangle = grid_rect(x, 3, width, 0.5),
+                    text = text,
+                    color = foreground_color,
+                    font_size = theme.font_size * Drawing.scale,
+                    font_name = 'Consolas',
+                    align_x = BreitbandGraphics.alignment.center,
+                    align_y = BreitbandGraphics.alignment.center,
+                })
 
                 if ugui.button({
                         uid = UID.AtanButtons + index * 2,
@@ -247,35 +252,38 @@ return {
         -- Shift elements down to make place for atan panel if atan strain is enabled.
         local YORG = Settings.tas.atan_strain and 4 or 3
 
-        BreitbandGraphics.draw_text(
-            grid_rect(4, YORG, 2, 1),
-            'center',
-            'center',
-            { aliased = not theme.cleartype },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            'Consolas',
-            'X: ' .. stick_x)
+        ugui.label({
+            uid = UID.StickX,
+            rectangle = grid_rect(4, YORG, 2, 1),
+            text = 'X: ' .. stick_x,
+            color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = 'Consolas',
+            align_x = BreitbandGraphics.alignment.center,
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
-        BreitbandGraphics.draw_text(
-            grid_rect(6, YORG, 2, 1),
-            'center',
-            'center',
-            { aliased = not theme.cleartype },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            'Consolas',
-            'Y: ' .. stick_y)
+        ugui.label({
+            uid = UID.StickY,
+            rectangle = grid_rect(6, YORG, 2, 1),
+            text = 'Y: ' .. stick_y,
+            color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = 'Consolas',
+            align_x = BreitbandGraphics.alignment.center,
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
-        BreitbandGraphics.draw_text(
-            grid_rect(4, YORG + 1, 4, 1),
-            'center',
-            'center',
-            { aliased = not theme.cleartype, fit = true },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            'Consolas',
-            'Mag: ' .. Formatter.u(Engine.get_magnitude_for_stick(stick_x, stick_y), 0))
+        ugui.label({
+            uid = UID.StickMag,
+            rectangle = grid_rect(4, YORG + 1, 4, 1),
+            text = 'Mag: ' .. Formatter.u(Engine.get_magnitude_for_stick(stick_x, stick_y), 0),
+            color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = 'Consolas',
+            align_x = BreitbandGraphics.alignment.center,
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         Settings.tas.goal_mag = math.abs(ugui.numberbox({
             uid = UID.GoalMag,

--- a/src/views/Timer.lua
+++ b/src/views/Timer.lua
@@ -26,6 +26,7 @@ local UID = UIDProvider.allocate_once('Timer', function(enum_next)
         CU = enum_next(),
         CD = enum_next(),
         ProcessedValues = enum_next(4),
+        TimerText = enum_next(),
     }
 end)
 
@@ -73,12 +74,16 @@ return {
             },
         })
 
-        BreitbandGraphics.draw_text(grid_rect(0, 5, 8, 1), 'center', 'center',
-            { aliased = not theme.cleartype },
-            BreitbandGraphics.invert_color(theme.background_color),
-            theme.font_size * Drawing.scale * 2,
-            'Consolas',
-            Timer.get_frame_text())
+        ugui.label({
+            uid = UID.TimerText,
+            rectangle = grid_rect(0, 5, 8, 1),
+            text = Timer.get_frame_text(),
+            color = BreitbandGraphics.invert_color(theme.background_color),
+            font_size = theme.font_size * Drawing.scale * 2,
+            font_name = 'Consolas',
+            align_x = BreitbandGraphics.alignment.center,
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         ugui.toggle_button({
             uid = UID.A,

--- a/src/views/Tools.lua
+++ b/src/views/Tools.lua
@@ -27,6 +27,12 @@ local UID = UIDProvider.allocate_once('Tools', function(enum_next)
         TrackMovedDistanceZ = enum_next(),
         FrameWalk = enum_next(),
         Swim = enum_next(),
+        RngLabel = enum_next(),
+        DumpingLabel = enum_next(),
+        GhostLabel = enum_next(),
+        TrackersLabel = enum_next(),
+        OverlaysLabel = enum_next(),
+        AutomationLabel = enum_next(),
     }
 end)
 
@@ -36,15 +42,14 @@ return {
         local theme = Styles.theme()
         local foreground_color = Drawing.foreground_color()
 
-        BreitbandGraphics.draw_text(
-            grid_rect(0, RNG_ROW - 1, 8, 1),
-            'start',
-            'center',
-            { aliased = not theme.cleartype },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            theme.font_name,
-            Locales.str('TOOLS_RNG'))
+        ugui.label({
+            uid = UID.RngLabel,
+            rectangle = grid_rect(0, RNG_ROW - 1, 8, 1),
+            text = Locales.str('TOOLS_RNG'),
+            color = foreground_color,
+            align_x = BreitbandGraphics.alignment['start'],
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         Settings.override_rng = ugui.toggle_button({
             uid = UID.RngLock,
@@ -68,15 +73,14 @@ return {
             maximum_value = math.maxinteger,
         }))
 
-        BreitbandGraphics.draw_text(
-            grid_rect(0, DUMPING_ROW - 1, 8, 1),
-            'start',
-            'center',
-            { aliased = not theme.cleartype },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            theme.font_name,
-            Locales.str('TOOLS_DUMPING'))
+        ugui.label({
+            uid = UID.DumpingLabel,
+            rectangle = grid_rect(0, DUMPING_ROW - 1, 8, 1),
+            text = Locales.str('TOOLS_DUMPING'),
+            color = foreground_color,
+            align_x = BreitbandGraphics.alignment['start'],
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         local previous_dump_enabled = Settings.dump_enabled
         local now_dump_enabled = ugui.toggle_button({
@@ -95,15 +99,14 @@ return {
         end
 
 
-        BreitbandGraphics.draw_text(
-            grid_rect(0, GHOST_ROW - 1, 8, 1),
-            'start',
-            'center',
-            { aliased = not theme.cleartype },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            theme.font_name,
-            Locales.str('TOOLS_GHOST'))
+        ugui.label({
+            uid = UID.GhostLabel,
+            rectangle = grid_rect(0, GHOST_ROW - 1, 8, 1),
+            text = Locales.str('TOOLS_GHOST'),
+            color = foreground_color,
+            align_x = BreitbandGraphics.alignment['start'],
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         if ugui.button({
                 uid = UID.RecordGhost,
@@ -125,15 +128,14 @@ return {
             end
         end
 
-        BreitbandGraphics.draw_text(
-            grid_rect(0, TRACKERS_ROW - 1, 8, 1),
-            'start',
-            'center',
-            { aliased = not theme.cleartype },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            theme.font_name,
-            Locales.str('TOOLS_TRACKERS'))
+        ugui.label({
+            uid = UID.TrackersLabel,
+            rectangle = grid_rect(0, TRACKERS_ROW - 1, 8, 1),
+            text = Locales.str('TOOLS_TRACKERS'),
+            color = foreground_color,
+            align_x = BreitbandGraphics.alignment['start'],
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         local track_moved_distance, meta = ugui.toggle_button({
             uid = UID.TrackMovedDistance,
@@ -171,15 +173,14 @@ return {
             is_checked = Settings.moved_distance_z,
         })
 
-        BreitbandGraphics.draw_text(
-            grid_rect(0, OVERLAYS_ROW - 1, 8, 1),
-            'start',
-            'center',
-            { aliased = not theme.cleartype },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            theme.font_name,
-            Locales.str('TOOLS_OVERLAYS'))
+        ugui.label({
+            uid = UID.OverlaysLabel,
+            rectangle = grid_rect(0, OVERLAYS_ROW - 1, 8, 1),
+            text = Locales.str('TOOLS_OVERLAYS'),
+            color = foreground_color,
+            align_x = BreitbandGraphics.alignment['start'],
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         Settings.worldviz_enabled = ugui.toggle_button({
             uid = UID.WorldVisualizer,
@@ -194,15 +195,14 @@ return {
             is_checked = Settings.mini_visualizer,
         })
 
-        BreitbandGraphics.draw_text(
-            grid_rect(0, AUTOMATION_ROW - 1, 8, 1),
-            'start',
-            'center',
-            { aliased = not theme.cleartype },
-            foreground_color,
-            theme.font_size * Drawing.scale * 1.25,
-            theme.font_name,
-            Locales.str('TOOLS_AUTOMATION'))
+        ugui.label({
+            uid = UID.AutomationLabel,
+            rectangle = grid_rect(0, AUTOMATION_ROW - 1, 8, 1),
+            text = Locales.str('TOOLS_AUTOMATION'),
+            color = foreground_color,
+            align_x = BreitbandGraphics.alignment['start'],
+            align_y = BreitbandGraphics.alignment.center,
+        })
 
         local _, meta = ugui.toggle_button({
             uid = UID.AutoFirsties,

--- a/src/views/Tools.lua
+++ b/src/views/Tools.lua
@@ -47,6 +47,8 @@ return {
             rectangle = grid_rect(0, RNG_ROW - 1, 8, 1),
             text = Locales.str('TOOLS_RNG'),
             color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = theme.font_name,
             align_x = BreitbandGraphics.alignment['start'],
             align_y = BreitbandGraphics.alignment.center,
         })
@@ -78,6 +80,8 @@ return {
             rectangle = grid_rect(0, DUMPING_ROW - 1, 8, 1),
             text = Locales.str('TOOLS_DUMPING'),
             color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = theme.font_name,
             align_x = BreitbandGraphics.alignment['start'],
             align_y = BreitbandGraphics.alignment.center,
         })
@@ -104,6 +108,8 @@ return {
             rectangle = grid_rect(0, GHOST_ROW - 1, 8, 1),
             text = Locales.str('TOOLS_GHOST'),
             color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = theme.font_name,
             align_x = BreitbandGraphics.alignment['start'],
             align_y = BreitbandGraphics.alignment.center,
         })
@@ -133,6 +139,8 @@ return {
             rectangle = grid_rect(0, TRACKERS_ROW - 1, 8, 1),
             text = Locales.str('TOOLS_TRACKERS'),
             color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = theme.font_name,
             align_x = BreitbandGraphics.alignment['start'],
             align_y = BreitbandGraphics.alignment.center,
         })
@@ -178,6 +186,8 @@ return {
             rectangle = grid_rect(0, OVERLAYS_ROW - 1, 8, 1),
             text = Locales.str('TOOLS_OVERLAYS'),
             color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = theme.font_name,
             align_x = BreitbandGraphics.alignment['start'],
             align_y = BreitbandGraphics.alignment.center,
         })
@@ -200,6 +210,8 @@ return {
             rectangle = grid_rect(0, AUTOMATION_ROW - 1, 8, 1),
             text = Locales.str('TOOLS_AUTOMATION'),
             color = foreground_color,
+            font_size = theme.font_size * Drawing.scale * 1.25,
+            font_name = theme.font_name,
             align_x = BreitbandGraphics.alignment['start'],
             align_y = BreitbandGraphics.alignment.center,
         })


### PR DESCRIPTION
 Summary

  Replace direct BreitbandGraphics.draw_text / draw_text2 calls with ugui.label across the codebase.

  Motivation

  Manually drawing text bypasses ugui's widget layer entirely, which:
  - locks us out of upstream enhancements (selectable/copyable labels, keyboard navigation, accessibility improvements)
  - duplicates layout/styling logic that ugui already handles
  - makes text inconsistent with the rest of the UI surface

  Using ugui.label makes text a proper first-class widget, no different from buttons or textboxes.

  Changes

  - Replaced all raw BreitbandGraphics.draw_text / draw_text2 calls in views (TAS, Tools, Timer, Notifications,
  SemanticWorkflow/*) with equivalent ugui.label calls
  - Text rendering behavior is preserved — this is a pure refactor with no visible change in output

  Benefits

  - Progressive enhancement — selectable labels, copy-to-clipboard, and a11y features flow in automatically from ugui
  upstream without further changes on our side
  - Consistency — all rendered text now goes through the same widget pipeline
  - Less surface area — no more manually threading font/color/alignment args through BreitbandGraphics
