### PR TITLE
fix(SemanticWorkflow): localized tab text not updating

### DIFF
--- a/src/views/SemanticWorkflow/Implementations/InputsTab.lua
+++ b/src/views/SemanticWorkflow/Implementations/InputsTab.lua
@@ -8,7 +8,7 @@
 ---@diagnostic disable-next-line: assign-type-mismatch
 local __impl = __impl
 
-__impl.name = function() return Locales.str 'SEMANTIC_WORKFLOW_INPUTS_TAB_NAME' end
+__impl.name = function() return Locales.str('SEMANTIC_WORKFLOW_INPUTS_TAB_NAME') end
 __impl.help_key = 'INPUTS_TAB'
 
 ---@type FrameListGui

--- a/src/views/SemanticWorkflow/Implementations/InputsTab.lua
+++ b/src/views/SemanticWorkflow/Implementations/InputsTab.lua
@@ -8,7 +8,7 @@
 ---@diagnostic disable-next-line: assign-type-mismatch
 local __impl = __impl
 
-__impl.name = 'Inputs'
+__impl.name = function() return Locales.str 'SEMANTIC_WORKFLOW_INPUTS_TAB_NAME' end
 __impl.help_key = 'INPUTS_TAB'
 
 ---@type FrameListGui
@@ -36,7 +36,7 @@ local selected_view_index = 1
 local previous_preview_frame
 local atan_start = 0
 
-local UID = UIDProvider.allocate_once(__impl.name, function(enum_next)
+local UID = UIDProvider.allocate_once('InputsTab', function(enum_next)
     return {
         ViewCarrousel = enum_next(),
         InsertInput = enum_next(),

--- a/src/views/SemanticWorkflow/Implementations/PreferencesTab.lua
+++ b/src/views/SemanticWorkflow/Implementations/PreferencesTab.lua
@@ -8,13 +8,13 @@
 ---@diagnostic disable-next-line: assign-type-mismatch
 local __impl = __impl
 
-__impl.name = 'Preferences'
+__impl.name = function() return Locales.str 'SEMANTIC_WORKFLOW_PREFERENCES_TAB_NAME' end
 __impl.help_key = 'PREFERENCES_TAB'
 
 ---@type Gui
 local Gui = dofile(views_path .. 'SemanticWorkflow/Definitions/Gui.lua')
 
-local UID = UIDProvider.allocate_once(__impl.name, function(enum_next)
+local UID = UIDProvider.allocate_once('PreferencesTab', function(enum_next)
     return {
         ToggleEditEntireState = enum_next(),
         ToggleFastForward = enum_next(),

--- a/src/views/SemanticWorkflow/Implementations/PreferencesTab.lua
+++ b/src/views/SemanticWorkflow/Implementations/PreferencesTab.lua
@@ -8,7 +8,7 @@
 ---@diagnostic disable-next-line: assign-type-mismatch
 local __impl = __impl
 
-__impl.name = function() return Locales.str 'SEMANTIC_WORKFLOW_PREFERENCES_TAB_NAME' end
+__impl.name = function() return Locales.str('SEMANTIC_WORKFLOW_PREFERENCES_TAB_NAME') end
 __impl.help_key = 'PREFERENCES_TAB'
 
 ---@type Gui

--- a/src/views/SemanticWorkflow/Implementations/ProjectTab.lua
+++ b/src/views/SemanticWorkflow/Implementations/ProjectTab.lua
@@ -8,7 +8,7 @@
 ---@diagnostic disable-next-line: assign-type-mismatch
 local __impl = __impl
 
-__impl.name = 'Project'
+__impl.name = function() return Locales.str 'SEMANTIC_WORKFLOW_PROJECT_TAB_NAME' end
 __impl.help_key = 'PROJECT_TAB'
 
 ---@type Project
@@ -17,7 +17,7 @@ local Project = dofile(views_path .. 'SemanticWorkflow/Definitions/Project.lua')
 ---@type Gui
 local Gui = dofile(views_path .. 'SemanticWorkflow/Definitions/Gui.lua')
 
-local UID = UIDProvider.allocate_once(__impl.name, function(enum_next)
+local UID = UIDProvider.allocate_once('ProjectTab', function(enum_next)
     return {
         NewProject = enum_next(),
         OpenProject = enum_next(),

--- a/src/views/SemanticWorkflow/Implementations/ProjectTab.lua
+++ b/src/views/SemanticWorkflow/Implementations/ProjectTab.lua
@@ -8,7 +8,7 @@
 ---@diagnostic disable-next-line: assign-type-mismatch
 local __impl = __impl
 
-__impl.name = function() return Locales.str 'SEMANTIC_WORKFLOW_PROJECT_TAB_NAME' end
+__impl.name = function() return Locales.str('SEMANTIC_WORKFLOW_PROJECT_TAB_NAME') end
 __impl.help_key = 'PROJECT_TAB'
 
 ---@type Project

--- a/src/views/SemanticWorkflow/Main.lua
+++ b/src/views/SemanticWorkflow/Main.lua
@@ -160,7 +160,7 @@ return {
         selected_tab_index = ugui.tabcontrol({
             uid = UID.SelectTab,
             rectangle = grid_rect(0, 0, 6, 1),
-            items = project_loaded and lualinq.select(Tabs, function(e) return e.name end) or { Tabs[1].name },
+            items = project_loaded and lualinq.select(Tabs, function(e) return e.name() end) or { Tabs[1].name() },
             selected_index = selected_tab_index,
         }).selected_index
 


### PR DESCRIPTION
This pull request updates the naming and localization strategy for the Semantic Workflow tabs. Instead of using static string names, the tab names are now functions that return localized strings, improving internationalization support. Additionally, the UID allocation for each tab has been decoupled from the localized name, using a fixed identifier instead to avoid issues with dynamic names.

**Localization improvements:**

* Changed `__impl.name` in `InputsTab.lua`, `PreferencesTab.lua`, and `ProjectTab.lua` from static strings to functions returning localized strings via `Locales.str`, enabling proper tab name localization. [[1]](diffhunk://#diff-1a56fbbfcbc405eae79391ce246679e2e09e4a8a8a01a17eb1fcc8dcd99d172eL11-R11) [[2]](diffhunk://#diff-013539648369e070ba72950e1db81ea07e68543245b0f971eda431b77a069dd4L11-R17) [[3]](diffhunk://#diff-95610f16b6aca2ba6f1f0d17fb5996a512275798cc4ef83c78fa61790b4b57c9L11-R11)
* Updated the tab selection logic in `Main.lua` to use the new function-based tab names, ensuring the UI displays the correct localized names.

**UID allocation adjustments:**

* Modified UID allocation in each tab implementation to use a fixed string identifier (e.g., `'InputsTab'`, `'PreferencesTab'`, `'ProjectTab'`) instead of the (now dynamic) tab name, preventing issues with changing names and ensuring stable UID generation. [[1]](diffhunk://#diff-1a56fbbfcbc405eae79391ce246679e2e09e4a8a8a01a17eb1fcc8dcd99d172eL39-R39) [[2]](diffhunk://#diff-013539648369e070ba72950e1db81ea07e68543245b0f971eda431b77a069dd4L11-R17) [[3]](diffhunk://#diff-95610f16b6aca2ba6f1f0d17fb5996a512275798cc4ef83c78fa61790b4b57c9L20-R20)  semantic workflow tabs

changelog: skip