### PR TITLE
(feat/project-file+validation) validate project and sheet files on load

### DIFF
--- a/src/views/Notifications.lua
+++ b/src/views/Notifications.lua
@@ -9,7 +9,7 @@ local notifications = {}
 -- For now, we only show one notification at a time, as opacity and slide animations are pretty distracting.
 
 return {
-    show = function(text)
+    show = function(text, duration)
         if Settings.notification_style == NOTIFICATION_STYLE_CONSOLE then
             print(text)
             return
@@ -21,7 +21,8 @@ return {
 
         notifications[#notifications + 1] = {
             text = text,
-            time = os.clock(),
+            time = nil,
+            duration = duration or 1,
         }
     end,
     draw = function()
@@ -36,6 +37,9 @@ return {
 
         for i = 1, #notifications, 1 do
             local notification = notifications[i]
+            if notification.time == nil then
+                notification.time = os.clock()
+            end
 
             local size = BreitbandGraphics.get_text_size(notification.text, theme.font_size * Drawing.scale * text_scale,
                 theme.font_name)
@@ -72,7 +76,7 @@ return {
         for i = #notifications, 1, -1 do
             local notification = notifications_copy[i]
 
-            if os.clock() - notification.time > 1 then
+            if notification.time ~= nil and os.clock() - notification.time > notification.duration then
                 table.remove(notifications, i)
             end
         end

--- a/src/views/SemanticWorkflow/Definitions/Validation.lua
+++ b/src/views/SemanticWorkflow/Definitions/Validation.lua
@@ -1,0 +1,26 @@
+--
+-- Copyright (c) 2025, Mupen64 maintainers.
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
+---@class Validation Provides validation functions for project and sheet files.
+local cls_validation = {}
+
+---Validates the decoded contents of a sheet file (.sws).
+---@param data table The decoded JSON data to validate.
+---@return boolean ok Whether the data is valid.
+---@return string | nil err A human-readable error message if the data is invalid, nil otherwise.
+function cls_validation.validate_sheet(data) end
+
+---Validates the decoded contents of a project file (.swp).
+---@param data table The decoded JSON data to validate.
+---@return boolean ok Whether the data is valid.
+---@return string | nil err A human-readable error message if the data is invalid, nil otherwise.
+function cls_validation.validate_project(data) end
+
+__impl = cls_validation
+dofile(views_path .. 'SemanticWorkflow/Implementations/Validation.lua')
+__impl = nil
+
+return cls_validation

--- a/src/views/SemanticWorkflow/Implementations/Project.lua
+++ b/src/views/SemanticWorkflow/Implementations/Project.lua
@@ -130,8 +130,18 @@ function __impl:project_folder()
 end
 
 function __impl:load(file)
+    local parse_ok, decoded = pcall(json.decode, ReadAll(file))
+    if not parse_ok then
+        Notifications.show('Failed to load project: invalid JSON', 5)
+        return
+    end
+    local ok, err = Validation.validate_project(decoded)
+    if not ok then
+        Notifications.show('Failed to load project: ' .. err, 5)
+        return
+    end
     self.project_location = file
-    CloneInto(self.meta, json.decode(ReadAll(file)))
+    CloneInto(self.meta, decoded)
     self.all = {}
     local project_folder = self:project_folder()
     for _, sheet_meta in ipairs(self.meta.sheets) do

--- a/src/views/SemanticWorkflow/Implementations/Sheet.lua
+++ b/src/views/SemanticWorkflow/Implementations/Sheet.lua
@@ -146,13 +146,20 @@ function __impl:save(file)
 end
 
 function __impl:load(file, load_state)
-    local contents = json.decode(ReadAll(file));
-    if contents ~= nil then
-        if load_state then
-            self._savestate = ReadAll(file .. '.savestate')
-        end
-        CloneInto(self, contents)
+    local parse_ok, contents = pcall(json.decode, ReadAll(file))
+    if not parse_ok then
+        Notifications.show('Failed to load sheet "' .. self.name .. '": invalid JSON', 5)
+        return
     end
+    local ok, err = Validation.validate_sheet(contents)
+    if not ok then
+        Notifications.show('Failed to load sheet "' .. self.name .. '": ' .. err, 5)
+        return
+    end
+    if load_state then
+        self._savestate = ReadAll(file .. '.savestate')
+    end
+    CloneInto(self, contents)
 end
 
 function __impl:rebase()

--- a/src/views/SemanticWorkflow/Implementations/Validation.lua
+++ b/src/views/SemanticWorkflow/Implementations/Validation.lua
@@ -1,0 +1,60 @@
+--
+-- Copyright (c) 2025, Mupen64 maintainers.
+--
+-- SPDX-License-Identifier: GPL-2.0-or-later
+--
+
+---@type Validation
+---@diagnostic disable-next-line:assign-type-mismatch
+local __impl = __impl
+
+function __impl.validate_sheet(data)
+    if type(data) ~= 'table' then
+        return false, 'Sheet file is not valid JSON'
+    end
+    if type(data.version) ~= 'string' then
+        return false, 'Sheet file is missing a version field'
+    end
+    if data.version ~= SEMANTIC_WORKFLOW_FILE_VERSION then
+        return false, 'Sheet version ' .. tostring(data.version) .. ' is not compatible with current version ' .. SEMANTIC_WORKFLOW_FILE_VERSION
+    end
+    if type(data.name) ~= 'string' then
+        return false, 'Sheet file is missing a name field'
+    end
+    if type(data.sections) ~= 'table' then
+        return false, 'Sheet file is missing a sections field'
+    end
+    for i, section in ipairs(data.sections) do
+        if type(section.end_action) ~= 'number' then
+            return false, 'Section ' .. i .. ' is missing a valid end_action field'
+        end
+        if type(section.timeout) ~= 'number' then
+            return false, 'Section ' .. i .. ' is missing a valid timeout field'
+        end
+        if type(section.inputs) ~= 'table' then
+            return false, 'Section ' .. i .. ' is missing a valid inputs field'
+        end
+    end
+    return true, nil
+end
+
+function __impl.validate_project(data)
+    if type(data) ~= 'table' then
+        return false, 'Project file is not valid JSON'
+    end
+    if type(data.version) ~= 'string' then
+        return false, 'Project file is missing a version field'
+    end
+    if data.version ~= SEMANTIC_WORKFLOW_FILE_VERSION then
+        return false, 'Project version ' .. tostring(data.version) .. ' is not compatible with current version ' .. SEMANTIC_WORKFLOW_FILE_VERSION
+    end
+    if type(data.sheets) ~= 'table' then
+        return false, 'Project file is missing a sheets field'
+    end
+    for i, sheet_meta in ipairs(data.sheets) do
+        if type(sheet_meta.name) ~= 'string' or #sheet_meta.name == 0 then
+            return false, 'Sheet entry ' .. i .. ' is missing a valid name field'
+        end
+    end
+    return true, nil
+end

--- a/src/views/SemanticWorkflow/Main.lua
+++ b/src/views/SemanticWorkflow/Main.lua
@@ -67,6 +67,9 @@ end
 
 local UID = dofile(views_path .. 'SemanticWorkflow/SharedUIDs.lua')
 
+---@type Validation
+Validation = dofile(views_path .. 'SemanticWorkflow/Definitions/Validation.lua')
+
 ---@type Project
 local Project = dofile(views_path .. 'SemanticWorkflow/Definitions/Project.lua')
 


### PR DESCRIPTION
This pull request introduces a validation layer for loading Semantic Workflow project and sheet files, improving error handling and user feedback. Now, both project and sheet files are checked for JSON validity and required fields before being loaded, and clear notifications are shown on failure. Additionally, notification display logic is improved to support custom durations.

**Validation and error handling improvements:**

* Added a new `Validation` module (`Validation.lua` and `Implementations/Validation.lua`) that provides `validate_project` and `validate_sheet` functions to ensure loaded files are valid and compatible with the current application version. [[1]](diffhunk://#diff-81892614d06c21b907dd274c010987894a8009ad3e0f0113ccb54df5d1549b71R1-R26) [[2]](diffhunk://#diff-fed59e38569aa2db5407fa77834a9cc8fdfc399bf357fa4b6093b8336e6da877R1-R60) [[3]](diffhunk://#diff-cae88096e575843112f0a08385cf68ca9fb5717d07668bf75d12698b77bc6072R70-R72)
* Updated project (`Project.lua`) and sheet (`Sheet.lua`) loading logic to use the new validation functions, showing user-friendly error messages via notifications when loading fails due to invalid JSON or schema issues. [[1]](diffhunk://#diff-09a609f2ef8fdafea46fc0e92efc65e0c62254949735f3e3f377b42802f20571R133-R144) [[2]](diffhunk://#diff-eb3ab0f8df12f1c1e706be09690157c1e28c42f95bde65c793dbc6f5cfc6c3b1L149-L156)

**Notification system enhancements:**

* Modified the `Notifications.show` function to accept a custom `duration` parameter, allowing notifications to be displayed for a variable amount of time. [[1]](diffhunk://#diff-964b6e2bdc2ffa09bb80b2c3a4aef854479bae27c7276b599c82aae81e301591L12-R12) [[2]](diffhunk://#diff-964b6e2bdc2ffa09bb80b2c3a4aef854479bae27c7276b599c82aae81e301591L24-R25) [[3]](diffhunk://#diff-964b6e2bdc2ffa09bb80b2c3a4aef854479bae27c7276b599c82aae81e301591R40-R42) [[4]](diffhunk://#diff-964b6e2bdc2ffa09bb80b2c3a4aef854479bae27c7276b599c82aae81e301591L75-R79)