### PR TITLE
chore: add `lib` directory to `workspace.library` in `.luarc`

### DIFF
--- a/.luarc
+++ b/.luarc
@@ -44,5 +44,5 @@
   ],
   "workspace.library": [
     "lib"
-]
+  ]
 }

--- a/.luarc
+++ b/.luarc
@@ -42,4 +42,7 @@
   "diagnostics.disable": [
     "lowercase-global"
   ],
+  "workspace.library": [
+    "lib"
+]
 }


### PR DESCRIPTION
This pull request makes a small configuration update to the `.luarc` file. The change adds the `lib` directory to the Lua workspace library, which helps the language server recognize and provide better tooling support for code in that directory. #97 