### PR TITLE
fix(Presets): change preset index application method

### DIFF
--- a/src/SM64Lua.lua
+++ b/src/SM64Lua.lua
@@ -266,7 +266,7 @@ local function draw_navbar()
     })
 
     if preset_index ~= Presets.persistent.current_index then
-        Presets.apply(preset_index)
+        Presets.change_index(preset_index)
         Actions.notify_all_changed()
     end
 end


### PR DESCRIPTION
This pull request makes a small update to the way preset selection is handled in the navigation bar. Instead of directly applying the preset when the index changes, it now changes the preset index, which may improve clarity or maintain consistency in preset management.
#101
