### PR TITLE
fix(Presets): memory source not updating when changing preset

### DIFF
--- a/src/core/Presets.lua
+++ b/src/core/Presets.lua
@@ -21,6 +21,9 @@ Presets.persistent.presets[1] = ugui.internal.deep_clone(DEFAULT_PRESET)
 function Presets.apply(i)
     Presets.persistent.current_index = ugui.internal.clamp(i, 1, #Presets.persistent.presets)
     Settings = Presets.persistent.presets[Presets.persistent.current_index]
+    if Settings.autodetect_address then
+        Settings.address_source_index = Memory.find_matching_address_source_index()
+    end
     Styles.update_style()
 end
 


### PR DESCRIPTION
This pull request makes a targeted improvement to the preset application logic by ensuring that when a preset with `autodetect_address` enabled is applied, the correct address source is automatically detected and set. This helps maintain expected behavior when switching presets.

Preset application logic:

* Updated `Presets.apply` in `src/core/Presets.lua` to automatically set `Settings.address_source_index` using `Memory.find_matching_address_source_index()` when `Settings.autodetect_address` is true.
close #103 