### PR TITLE
fix(perf): revert to manual throttling for fast-forward to avoid freeze on Mupen64 beta

### DIFF
--- a/src/SM64Lua.lua
+++ b/src/SM64Lua.lua
@@ -91,6 +91,9 @@ Notifications = dofile(views_path .. 'Notifications.lua')
 ugui_environment = {}
 local mouse_wheel = 0
 
+-- Track the last time a frame was painted for manual fast-forward throttling
+local last_paint_time = os.clock()
+
 -- Flag keeping track of whether atinput has fired for one time
 local first_input = true
 
@@ -267,7 +270,16 @@ local function draw_navbar()
 end
 
 local function atdrawd2d()
-    d2d.set_target_fps(emu.get_ff() and Settings.ff_fps or nil)
+    -- TODO: Replace time-based throttling with selective rendering.
+    -- FramePerfection's feedback: render only specific frames (last in semantic
+    -- workflow, bruteforce improvements) rather than skipping arbitrary frames
+    -- by timer. This workaround avoids the freeze on Mupen64 beta 1.4.0.
+    if emu.get_ff() then
+        if os.clock() - last_paint_time < 1 / Settings.ff_fps then
+            return
+        end
+        last_paint_time = os.clock()
+    end
 
     if d2d and d2d.clear then
         d2d.clear(0, 0, 0, 0)


### PR DESCRIPTION
## Summary
Hypothetical fix for fast-forward freeze reported on Mupen64 **1.4.0-beta-93faaf96**.

## Problem
When fast-forward is active (e.g. holding the FF button in the emulator), the game freezes — only UI counters move, no actual frame advance occurs. Normal TAS frame-advance works perfectly fine.

**Affected workflow:** Semantic Workflow tab → run to preview with fast-forward enabled, or simply toggling fast-forward during TAS playback.

## Root Cause Analysis
Commit `a49a1a1` ("perf: use `d2d.set_target_fps` for throttling during ff") replaced the manual draw-frame throttling with a single `d2d.set_target_fps()` call:

```lua
d2d.set_target_fps(emu.get_ff() and Settings.ff_fps or nil)
```

`d2d.set_target_fps()` is a relatively new D2D renderer API. On the **Mupen64 beta build 1.4.0-beta-93faaf96**, this API appears to interact badly with the emulator's fast-forward logic — likely because the beta's D2D backend does not correctly handle FPS throttling when the core is running at ultra-fast-forward speed. The result is that the renderer blocks or desynchronizes from the emulation core, causing the observed freeze.

## Hypothesis
**The root cause is most likely in Mupen64 itself** (the beta D2D backend), not in SM64LuaRedux. SM64LuaRedux merely triggered the bug by adopting the new API. However, since users cannot easily switch Mupen64 versions mid-TAS, a defensive fix in SM64LuaRedux is warranted.

## Fix
Reverts to the pre-`a49a1a1` manual throttling approach in `atdrawd2d()`:
- Re-introduce `local last_paint_time = os.clock()`
- Skip draw frames during fast-forward if not enough time elapsed (`os.clock() - last_paint_time < 1 / Settings.ff_fps`)
- Update `last_paint_time` only when a frame is actually drawn
- When fast-forward is off, draw normally without any throttling

This removes the dependency on the potentially unstable `d2d.set_target_fps` API and restores the proven behavior from before commit `a49a1a1`.

## Known Limitations / Future Work
Per feedback from @FramePerfection, the **ideal** long-term solution is **selective rendering** — not throttling by time, but rendering only specific frames (particularly the final frame of a semantic workflow run, or bruteforce improvements). This PR is a **stopgap workaround** that restores a working fast-forward experience on the beta build. A follow-up should implement selective frame rendering so that intermediate states are intentionally skipped rather than arbitrarily throttled by a timer.

## Testing Needed
⚠️ **This fix is hypothetical.** The root cause may be in Mupen64 itself rather than SM64LuaRedux. Testing on the reported beta build (`1.4.0-beta-93faaf96`) is strongly recommended before merging.

Please verify:
1. Fast-forward no longer freezes when running a Semantic Workflow project
2. Frame-advance still works correctly
3. UI remains responsive during fast-forward
4. Performance is acceptable (throttling still reduces CPU load as intended)

## Files Changed
- `src/SM64Lua.lua`

## Related
- Commit `a49a1a1` — original `d2d.set_target_fps` optimization (#88)
- Mupen64 version: `1.4.0-beta-93faaf96`

---
**Requesting review from** @FramePerfection @Aurumaker72 — please test on the beta build and let me know if the workaround is acceptable or if you'd prefer a different approach.
